### PR TITLE
fix Vector2.setY and Vector2.setX

### DIFF
--- a/src/Native/Math/Vector2.js
+++ b/src/Native/Math/Vector2.js
@@ -55,10 +55,10 @@ var _elm_community$elm_linear_algebra$Native_Math_Vector2 = function() {
         return a[1];
     }
     V2.setX = function V2_setX(x, a) {
-        return new MJS_FLOAT_ARRAY_TYPE(x, a[1]);
+        return new MJS_FLOAT_ARRAY_TYPE([x, a[1]]);
     }
     V2.setY = function V2_setY(y, a) {
-        return new MJS_FLOAT_ARRAY_TYPE(a[0], y);
+        return new MJS_FLOAT_ARRAY_TYPE([a[0], y]);
     }
 
     V2.toTuple = function V2_toTuple(a) {


### PR DESCRIPTION
# Real PR is here: https://github.com/elm-community/elm-linear-algebra/pull/15

~~It won't break since the functions don't work at moment. Invoking `Float32Array` with no Array simply returns a _Float32Array_ prefilled with ten zeros.~~
